### PR TITLE
fix(#592): Introduce build order strategy

### DIFF
--- a/docs/modules/ROOT/pages/architecture/cr/build.adoc
+++ b/docs/modules/ROOT/pages/architecture/cr/build.adoc
@@ -36,6 +36,15 @@ At the moment the available strategies are:
 - buildStrategy: pod (each build is run in a separate pod, the operator monitors the pod state)
 - buildStrategy: routine (each build is run as a go routine inside the operator pod)
 
+[[build-order-strategy]]
+== Build order strategy
+
+You can choose from different build order strategies. The strategy defines in which order queued builds are run.
+At the moment the available strategies are:
+
+- buildOrderStrategy: sequential (runs builds strictly sequential so that only one single build per operator namespace is running at a time.)
+- buildOrderStrategy: fifo (performs the builds with first in first out strategy based on the creation timestamp. The strategy allows builds to run in parallel to each other but oldest builds will be run first.)
+
 [[build-queue]]
 == Build queues
 

--- a/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
@@ -26,6 +26,7 @@ We have several configuration used to influence the building of an integration:
 --build-publish-strategy string               Set the build publish strategy
 --build-publish-strategy-option stringArray   Add a build publish strategy option, as <name=value>
 --build-strategy string                       Set the build strategy
+--build-order-strategy string                 Set the build order strategy
 --build-timeout string                        Set how long the build process can last
 ```
 A very important set of configuration you can provide is related to Maven:

--- a/e2e/builder/build_test.go
+++ b/e2e/builder/build_test.go
@@ -45,8 +45,9 @@ func TestKitMaxBuildLimit(t *testing.T) {
 		createOperator(ns, "8m0s", "--global", "--force")
 
 		pl := Platform(ns)()
-		// set maximum number of running builds
+		// set maximum number of running builds and order strategy
 		pl.Spec.Build.MaxRunningBuilds = 2
+		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategySequential
 		if err := TestClient().Update(TestContext, pl); err != nil {
 			t.Error(err)
 			t.FailNow()
@@ -136,6 +137,80 @@ func TestKitMaxBuildLimit(t *testing.T) {
 				Eventually(KitPhase(ns2, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 			})
 		})
+	})
+}
+
+func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		createOperator(ns, "8m0s", "--global", "--force")
+
+		pl := Platform(ns)()
+		// set maximum number of running builds and order strategy
+		pl.Spec.Build.MaxRunningBuilds = 2
+		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategyFIFO
+		if err := TestClient().Update(TestContext, pl); err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+
+		buildA := "integration-a"
+		buildB := "integration-b"
+		buildC := "integration-c"
+
+		doKitBuildInNamespace(buildA, ns, TestTimeoutShort, kitOptions{
+			operatorID: fmt.Sprintf("camel-k-%s", ns),
+			dependencies: []string{
+				"camel:timer", "camel:log",
+			},
+			traits: []string{
+				"builder.properties=build-property=A",
+			},
+		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
+
+		doKitBuildInNamespace(buildB, ns, TestTimeoutShort, kitOptions{
+			operatorID: fmt.Sprintf("camel-k-%s", ns),
+			dependencies: []string{
+				"camel:timer", "camel:log",
+			},
+			traits: []string{
+				"builder.properties=build-property=B",
+			},
+		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
+
+		doKitBuildInNamespace(buildC, ns, TestTimeoutShort, kitOptions{
+			operatorID: fmt.Sprintf("camel-k-%s", ns),
+			dependencies: []string{
+				"camel:timer", "camel:log",
+			},
+			traits: []string{
+				"builder.properties=build-property=C",
+			},
+		}, v1.BuildPhaseScheduling, v1.IntegrationKitPhaseNone)
+
+		var notExceedsMaxBuildLimit = func(runningBuilds int) bool {
+			return runningBuilds <= 2
+		}
+
+		limit := 0
+		for limit < 5 && BuildPhase(ns, buildA)() == v1.BuildPhaseRunning {
+			// verify that number of running builds does not exceed max build limit
+			Consistently(BuildsRunning(BuildPhase(ns, buildA), BuildPhase(ns, buildB), BuildPhase(ns, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
+			limit++
+		}
+
+		// make sure we have verified max build limit at least once
+		if limit == 0 {
+			t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(ns, buildA)(), buildA)))
+			t.FailNow()
+		}
+
+		// verify that all builds are successful
+		Eventually(BuildPhase(ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		Eventually(KitPhase(ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		Eventually(BuildPhase(ns, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		Eventually(KitPhase(ns, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		Eventually(BuildPhase(ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		Eventually(KitPhase(ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 	})
 }
 

--- a/e2e/common/traits/builder_test.go
+++ b/e2e/common/traits/builder_test.go
@@ -51,6 +51,32 @@ func TestBuilderTrait(t *testing.T) {
 		integrationKitName := IntegrationKit(ns, name)()
 		builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
 		Eventually(BuildConfig(ns, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
+		Eventually(BuildConfig(ns, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
+		// Default resource CPU Check
+		Eventually(BuildConfig(ns, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
+		Eventually(BuildConfig(ns, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
+		Eventually(BuildConfig(ns, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
+		Eventually(BuildConfig(ns, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
+
+		Eventually(BuilderPod(ns, builderKitName), TestTimeoutShort).Should(BeNil())
+
+		// We need to remove the kit as well
+		Expect(Kamel("reset", "-n", ns).Execute()).To(Succeed())
+	})
+
+	t.Run("Run build order strategy fifo", func(t *testing.T) {
+		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+			"--name", name,
+			"-t", "builder.order-strategy=fifo").Execute()).To(Succeed())
+
+		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+
+		integrationKitName := IntegrationKit(ns, name)()
+		builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
+		Eventually(BuildConfig(ns, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyPod))
+		Eventually(BuildConfig(ns, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategyFIFO))
 		// Default resource CPU Check
 		Eventually(BuildConfig(ns, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
 		Eventually(BuildConfig(ns, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
@@ -81,6 +107,7 @@ func TestBuilderTrait(t *testing.T) {
 		builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
 
 		Eventually(BuildConfig(ns, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyPod))
+		Eventually(BuildConfig(ns, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
 		Eventually(BuildConfig(ns, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal("500m"))
 		Eventually(BuildConfig(ns, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal("1000m"))
 		Eventually(BuildConfig(ns, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal("2Gi"))

--- a/e2e/commonwithcustominstall/local_platform_test.go
+++ b/e2e/commonwithcustominstall/local_platform_test.go
@@ -82,6 +82,7 @@ func TestLocalPlatform(t *testing.T) {
 			local := Platform(ns1)()
 			Expect(local.Status.Build.PublishStrategy).To(Equal(pl.Status.Build.PublishStrategy))
 			Expect(local.Status.Build.BuildConfiguration.Strategy).To(Equal(pl.Status.Build.BuildConfiguration.Strategy))
+			Expect(local.Status.Build.BuildConfiguration.OrderStrategy).To(Equal(pl.Status.Build.BuildConfiguration.OrderStrategy))
 			Expect(local.Status.Build.Maven.LocalRepository).To(Equal(pl.Status.Build.Maven.LocalRepository))
 			Expect(local.Status.Build.Maven.CLIOptions).To(ContainElements(pl.Status.Build.Maven.CLIOptions))
 			Expect(local.Status.Build.Maven.Extension).To(BeEmpty())

--- a/pkg/apis/camel/v1/build_types_support.go
+++ b/pkg/apis/camel/v1/build_types_support.go
@@ -201,3 +201,28 @@ func (c BuildCondition) GetReason() string {
 func (c BuildCondition) GetMessage() string {
 	return c.Message
 }
+
+func (bl BuildList) HasRunningBuilds() bool {
+	for _, b := range bl.Items {
+		if b.Status.Phase == BuildPhasePending || b.Status.Phase == BuildPhaseRunning {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (bl BuildList) HasScheduledBuildsBefore(build *Build) bool {
+	for _, b := range bl.Items {
+		if b.Name == build.Name {
+			continue
+		}
+
+		if (b.Status.Phase == BuildPhaseInitialization || b.Status.Phase == BuildPhaseScheduling) &&
+			b.CreationTimestamp.Before(&build.CreationTimestamp) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -43,6 +43,8 @@ type BuildConfiguration struct {
 	BuilderPodNamespace string `json:"operatorNamespace,omitempty"`
 	// the strategy to adopt
 	Strategy BuildStrategy `property:"strategy" json:"strategy,omitempty"`
+	// the build order strategy to adopt
+	OrderStrategy BuildOrderStrategy `property:"order-strategy" json:"orderStrategy,omitempty"`
 	// The minimum amount of CPU required. Only used for `pod` strategy
 	RequestCPU string `property:"request-cpu" json:"requestCPU,omitempty"`
 	// The minimum amount of memory required. Only used for `pod` strategy
@@ -70,12 +72,28 @@ const (
 	// mitigated by the presence of a Maven proxy.
 	// Available for both Quarkus JVM and Native mode.
 	BuildStrategyPod BuildStrategy = "pod"
+
+	// BuildOrderStrategyFIFO performs the builds with first in first out strategy based on the creation timestamp.
+	// The strategy allows builds to run in parallel to each other but oldest builds will be run first.
+	BuildOrderStrategyFIFO BuildOrderStrategy = "fifo"
+	// BuildOrderStrategySequential runs builds strictly sequential so that only one single build per operator namespace is running at a time.
+	BuildOrderStrategySequential BuildOrderStrategy = "sequential"
 )
 
 // BuildStrategies is a list of strategies allowed for the build
 var BuildStrategies = []BuildStrategy{
 	BuildStrategyRoutine,
 	BuildStrategyPod,
+}
+
+// BuildOrderStrategy specifies how builds are reconciled and queued.
+// +kubebuilder:validation:Enum=fifo;sequential
+type BuildOrderStrategy string
+
+// BuildOrderStrategies is a list of order strategies allowed for the build
+var BuildOrderStrategies = []BuildOrderStrategy{
+	BuildOrderStrategyFIFO,
+	BuildOrderStrategySequential,
 }
 
 // ConfigurationSpec represents a generic configuration specification

--- a/pkg/apis/camel/v1/common_types_support.go
+++ b/pkg/apis/camel/v1/common_types_support.go
@@ -159,6 +159,7 @@ var _ json.Unmarshaler = (*RawMessage)(nil)
 // IsEmpty -- .
 func (bc *BuildConfiguration) IsEmpty() bool {
 	return bc.Strategy == "" &&
+		bc.OrderStrategy == "" &&
 		bc.RequestCPU == "" &&
 		bc.RequestMemory == "" &&
 		bc.LimitCPU == "" &&

--- a/pkg/apis/camel/v1/trait/builder.go
+++ b/pkg/apis/camel/v1/trait/builder.go
@@ -29,6 +29,8 @@ type BuilderTrait struct {
 	Properties []string `property:"properties" json:"properties,omitempty"`
 	// The strategy to use, either `pod` or `routine` (default routine)
 	Strategy string `property:"strategy" json:"strategy,omitempty"`
+	// The build order strategy to use, either `fifo` or `sequential` (default sequential)
+	OrderStrategy string `property:"order-strategy" json:"orderStrategy,omitempty"`
 	// When using `pod` strategy, the minimum amount of CPU required by the pod builder.
 	RequestCPU string `property:"request-cpu" json:"requestCPU,omitempty"`
 	// When using `pod` strategy, the minimum amount of memory required by the pod builder.

--- a/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
@@ -26,13 +26,14 @@ import (
 // BuildConfigurationApplyConfiguration represents an declarative configuration of the BuildConfiguration type for use
 // with apply.
 type BuildConfigurationApplyConfiguration struct {
-	ToolImage           *string           `json:"toolImage,omitempty"`
-	BuilderPodNamespace *string           `json:"operatorNamespace,omitempty"`
-	Strategy            *v1.BuildStrategy `json:"strategy,omitempty"`
-	RequestCPU          *string           `json:"requestCPU,omitempty"`
-	RequestMemory       *string           `json:"requestMemory,omitempty"`
-	LimitCPU            *string           `json:"limitCPU,omitempty"`
-	LimitMemory         *string           `json:"limitMemory,omitempty"`
+	ToolImage           *string                `json:"toolImage,omitempty"`
+	BuilderPodNamespace *string                `json:"operatorNamespace,omitempty"`
+	Strategy            *v1.BuildStrategy      `json:"strategy,omitempty"`
+	OrderStrategy       *v1.BuildOrderStrategy `json:"orderStrategy,omitempty"`
+	RequestCPU          *string                `json:"requestCPU,omitempty"`
+	RequestMemory       *string                `json:"requestMemory,omitempty"`
+	LimitCPU            *string                `json:"limitCPU,omitempty"`
+	LimitMemory         *string                `json:"limitMemory,omitempty"`
 }
 
 // BuildConfigurationApplyConfiguration constructs an declarative configuration of the BuildConfiguration type for use with
@@ -62,6 +63,14 @@ func (b *BuildConfigurationApplyConfiguration) WithBuilderPodNamespace(value str
 // If called multiple times, the Strategy field is set to the value of the last call.
 func (b *BuildConfigurationApplyConfiguration) WithStrategy(value v1.BuildStrategy) *BuildConfigurationApplyConfiguration {
 	b.Strategy = &value
+	return b
+}
+
+// WithOrderStrategy sets the OrderStrategy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the OrderStrategy field is set to the value of the last call.
+func (b *BuildConfigurationApplyConfiguration) WithOrderStrategy(value v1.BuildOrderStrategy) *BuildConfigurationApplyConfiguration {
+	b.OrderStrategy = &value
 	return b
 }
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -107,6 +107,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	cmd.Flags().String("operator-image", "", "Set the operator Image used for the operator deployment")
 	cmd.Flags().String("operator-image-pull-policy", "", "Set the operator ImagePullPolicy used for the operator deployment")
 	cmd.Flags().String("build-strategy", "", "Set the build strategy")
+	cmd.Flags().String("build-order-strategy", "", "Set the build order strategy")
 	cmd.Flags().String("build-publish-strategy", "", "Set the build publish strategy")
 	cmd.Flags().StringArray("build-publish-strategy-option", nil, "Add a build publish strategy option, as <name=value>")
 	cmd.Flags().String("build-timeout", "", "Set how long the build process can last")
@@ -181,6 +182,7 @@ type installCmdOptions struct {
 	OperatorImage               string   `mapstructure:"operator-image"`
 	OperatorImagePullPolicy     string   `mapstructure:"operator-image-pull-policy"`
 	BuildStrategy               string   `mapstructure:"build-strategy"`
+	BuildOrderStrategy          string   `mapstructure:"build-order-strategy"`
 	BuildPublishStrategy        string   `mapstructure:"build-publish-strategy"`
 	BuildPublishStrategyOptions []string `mapstructure:"build-publish-strategy-options"`
 	BuildTimeout                string   `mapstructure:"build-timeout"`
@@ -524,6 +526,9 @@ func (o *installCmdOptions) setupIntegrationPlatform(c client.Client, namespace 
 	if o.BuildStrategy != "" {
 		platform.Spec.Build.BuildConfiguration.Strategy = v1.BuildStrategy(o.BuildStrategy)
 	}
+	if o.BuildOrderStrategy != "" {
+		platform.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategy(o.BuildOrderStrategy)
+	}
 	if o.BuildPublishStrategy != "" {
 		platform.Spec.Build.PublishStrategy = v1.IntegrationPlatformBuildPublishStrategy(o.BuildPublishStrategy)
 	}
@@ -746,6 +751,23 @@ func (o *installCmdOptions) validate(_ *cobra.Command, _ []string) error {
 				strategies = append(strategies, string(s))
 			}
 			return fmt.Errorf("unknown build strategy: %s. One of [%s] is expected", o.BuildStrategy, strings.Join(strategies, ", "))
+		}
+	}
+
+	if o.BuildOrderStrategy != "" {
+		found := false
+		for _, s := range v1.BuildOrderStrategies {
+			if string(s) == o.BuildOrderStrategy {
+				found = true
+				break
+			}
+		}
+		if !found {
+			var strategies []string
+			for _, s := range v1.BuildOrderStrategies {
+				strategies = append(strategies, string(s))
+			}
+			return fmt.Errorf("unknown build order strategy: %s. One of [%s] is expected", o.BuildOrderStrategy, strings.Join(strategies, ", "))
 		}
 	}
 

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -107,6 +107,13 @@ func TestInstallBuildStrategyFlag(t *testing.T) {
 	assert.Equal(t, "someString", installCmdOptions.BuildStrategy)
 }
 
+func TestInstallBuildOrderStrategyFlag(t *testing.T) {
+	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--build-order-strategy", "someString")
+	assert.Nil(t, err)
+	assert.Equal(t, "someString", installCmdOptions.BuildOrderStrategy)
+}
+
 func TestInstallBuildTimeoutFlag(t *testing.T) {
 	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--build-timeout", "10")

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -147,7 +147,8 @@ func (r *reconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, err
 	}
 	buildMonitor := Monitor{
-		maxRunningBuilds: ip.Status.Build.MaxRunningBuilds,
+		maxRunningBuilds:   ip.Status.Build.MaxRunningBuilds,
+		buildOrderStrategy: ip.Status.Build.BuildConfiguration.OrderStrategy,
 	}
 
 	switch instance.BuilderConfiguration().Strategy {

--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -113,9 +113,16 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 		if buildConfig.IsEmpty() {
 			// default to IntegrationPlatform configuration
 			buildConfig = &env.Platform.Status.Build.BuildConfiguration
-		} else if buildConfig.Strategy == "" {
-			// we always need to define a strategy, so we default to platform if none
-			buildConfig.Strategy = env.Platform.Status.Build.BuildConfiguration.Strategy
+		} else {
+			if buildConfig.Strategy == "" {
+				// we always need to define a strategy, so we default to platform if none
+				buildConfig.Strategy = env.Platform.Status.Build.BuildConfiguration.Strategy
+			}
+
+			if buildConfig.OrderStrategy == "" {
+				// we always need to define an order strategy, so we default to platform if none
+				buildConfig.OrderStrategy = env.Platform.Status.Build.BuildConfiguration.OrderStrategy
+			}
 		}
 
 		// nolint: contextcheck

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -97,6 +97,11 @@ func ConfigureDefaults(ctx context.Context, c client.Client, p *v1.IntegrationPl
 		log.Debugf("Integration Platform %s [%s]: setting build strategy %s", p.Name, p.Namespace, p.Status.Build.BuildConfiguration.Strategy)
 	}
 
+	if p.Status.Build.BuildConfiguration.OrderStrategy == "" {
+		p.Status.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategySequential
+		log.Debugf("Integration Platform %s [%s]: setting build order strategy %s", p.Name, p.Namespace, p.Status.Build.BuildConfiguration.OrderStrategy)
+	}
+
 	err := setPlatformDefaults(p, verbose)
 	if err != nil {
 		return err
@@ -235,6 +240,10 @@ func applyPlatformSpec(source *v1.IntegrationPlatform, target *v1.IntegrationPla
 	}
 	if target.Status.Build.BuildConfiguration.Strategy == "" {
 		target.Status.Build.BuildConfiguration.Strategy = source.Status.Build.BuildConfiguration.Strategy
+	}
+
+	if target.Status.Build.BuildConfiguration.OrderStrategy == "" {
+		target.Status.Build.BuildConfiguration.OrderStrategy = source.Status.Build.BuildConfiguration.OrderStrategy
 	}
 
 	if target.Status.Build.RuntimeVersion == "" {

--- a/pkg/platform/defaults_test.go
+++ b/pkg/platform/defaults_test.go
@@ -40,7 +40,8 @@ func TestApplyGlobalPlatformSpec(t *testing.T) {
 		Spec: v1.IntegrationPlatformSpec{
 			Build: v1.IntegrationPlatformBuildSpec{
 				BuildConfiguration: v1.BuildConfiguration{
-					Strategy: v1.BuildStrategyRoutine,
+					Strategy:      v1.BuildStrategyRoutine,
+					OrderStrategy: v1.BuildOrderStrategyFIFO,
 				},
 				Maven: v1.MavenSpec{
 					Properties: map[string]string{
@@ -83,6 +84,7 @@ func TestApplyGlobalPlatformSpec(t *testing.T) {
 	assert.Equal(t, v1.IntegrationPlatformClusterOpenShift, ip.Status.Cluster)
 	assert.Equal(t, v1.TraitProfileOpenShift, ip.Status.Profile)
 	assert.Equal(t, v1.BuildStrategyRoutine, ip.Status.Build.BuildConfiguration.Strategy)
+	assert.Equal(t, v1.BuildOrderStrategyFIFO, ip.Status.Build.BuildConfiguration.OrderStrategy)
 	assert.True(t, ip.Status.Build.MaxRunningBuilds == 3) // default for build strategy routine
 	assert.Equal(t, len(global.Status.Build.Maven.CLIOptions), len(ip.Status.Build.Maven.CLIOptions))
 	assert.Equal(t, global.Status.Build.Maven.CLIOptions, ip.Status.Build.Maven.CLIOptions)
@@ -187,7 +189,8 @@ func TestRetainLocalPlatformSpec(t *testing.T) {
 		Spec: v1.IntegrationPlatformSpec{
 			Build: v1.IntegrationPlatformBuildSpec{
 				BuildConfiguration: v1.BuildConfiguration{
-					Strategy: v1.BuildStrategyRoutine,
+					Strategy:      v1.BuildStrategyRoutine,
+					OrderStrategy: v1.BuildOrderStrategySequential,
 				},
 				Maven: v1.MavenSpec{
 					Properties: map[string]string{
@@ -224,7 +227,8 @@ func TestRetainLocalPlatformSpec(t *testing.T) {
 		Spec: v1.IntegrationPlatformSpec{
 			Build: v1.IntegrationPlatformBuildSpec{
 				BuildConfiguration: v1.BuildConfiguration{
-					Strategy: v1.BuildStrategyPod,
+					Strategy:      v1.BuildStrategyPod,
+					OrderStrategy: v1.BuildOrderStrategyFIFO,
 				},
 				MaxRunningBuilds: 1,
 				Maven: v1.MavenSpec{
@@ -251,6 +255,7 @@ func TestRetainLocalPlatformSpec(t *testing.T) {
 	assert.Equal(t, v1.IntegrationPlatformClusterKubernetes, ip.Status.Cluster)
 	assert.Equal(t, v1.TraitProfileKnative, ip.Status.Profile)
 	assert.Equal(t, v1.BuildStrategyPod, ip.Status.Build.BuildConfiguration.Strategy)
+	assert.Equal(t, v1.BuildOrderStrategyFIFO, ip.Status.Build.BuildConfiguration.OrderStrategy)
 	assert.True(t, ip.Status.Build.MaxRunningBuilds == 1)
 	assert.Equal(t, len(global.Status.Build.Maven.CLIOptions), len(ip.Status.Build.Maven.CLIOptions))
 	assert.Equal(t, global.Status.Build.Maven.CLIOptions, ip.Status.Build.Maven.CLIOptions)


### PR DESCRIPTION
- Run builds on same operator namespace with user defined strategy
- Default strategy is "sequential" running only one single build at a time
- Also support "fifo" strategy where builds are run/queued based on their creation timestamp. This strategy allows parallel builds as long as individual build dependency lists are not colliding
- Users may adjust/overwrite the build order strategy via install command option, in the (local) integration platform settings or via the builder trait option
- Max number of running builds limitation is not affected by the build order strategy (ensure to always obey the limitation)

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
